### PR TITLE
Added preserve line to tokenizer

### DIFF
--- a/src/main/java/org/aksw/gerbil/python/mt/eval.py
+++ b/src/main/java/org/aksw/gerbil/python/mt/eval.py
@@ -76,7 +76,7 @@ def parse(refs_path, hyps_path, num_refs, lng='en'):
         if lng == 'ru':
             references_tok[i] = [' '.join([_.text for _ in tokenize(ref)]) for ref in refs]
         else:
-            references_tok[i] = [' '.join(nltk.word_tokenize(ref)) for ref in refs]
+            references_tok[i] = [' '.join(nltk.word_tokenize(ref, preserve_line=True)) for ref in refs]
 
     # hypothesis
     with codecs.open(hyps_path, 'r', 'utf-8') as f:
@@ -87,7 +87,7 @@ def parse(refs_path, hyps_path, num_refs, lng='en'):
     if lng == 'ru':
         hypothesis_tok = [' '.join([_.text for _ in tokenize(hyp)]) for hyp in hypothesis_tok]
     else:
-        hypothesis_tok = [' '.join(nltk.word_tokenize(hyp)) for hyp in hypothesis_tok]
+        hypothesis_tok = [' '.join(nltk.word_tokenize(hyp, preserve_line=True)) for hyp in hypothesis_tok]
 
 
     logging.info('FINISHING TO PARSE INPUTS...')


### PR DESCRIPTION
Some machine translation datasets like Europarl have punctuation at the beginning of the sentence:
`nltk.word_tokenize('. (EN) Mr President, I was in Iraq 12 days ago.')`

This causes it to fail with:
```
Traceback (most recent call last):
  File "src/main/java/org/aksw/gerbil/python/mt/eval.py", line 252, in <module>
    references, references_tok, hypothesis, hypothesis_tok = parse(refs_path, hyps_path, num_refs, lng)
  File "src/main/java/org/aksw/gerbil/python/mt/eval.py", line 91, in parse
    hypothesis_tok = [' '.join(nltk.word_tokenize(hyp)) for hyp in hypothesis_tok]
  File "src/main/java/org/aksw/gerbil/python/mt/eval.py", line 91, in <listcomp>
    hypothesis_tok = [' '.join(nltk.word_tokenize(hyp)) for hyp in hypothesis_tok]
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/__init__.py", line 129, in word_tokenize
    sentences = [text] if preserve_line else sent_tokenize(text, language)
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/__init__.py", line 107, in sent_tokenize
    return tokenizer.tokenize(text)
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/punkt.py", line 1276, in tokenize
    return list(self.sentences_from_text(text, realign_boundaries))
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/punkt.py", line 1332, in sentences_from_text
    return [text[s:e] for s, e in self.span_tokenize(text, realign_boundaries)]
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/punkt.py", line 1332, in <listcomp>
    return [text[s:e] for s, e in self.span_tokenize(text, realign_boundaries)]
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/punkt.py", line 1322, in span_tokenize
    for sentence in slices:
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/punkt.py", line 1421, in _realign_boundaries
    for sentence1, sentence2 in _pair_iter(slices):
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/punkt.py", line 318, in _pair_iter
    prev = next(iterator)
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/punkt.py", line 1395, in _slices_from_text
    for match, context in self._match_potential_end_contexts(text):
  File "/home/diegomoussallem/.local/lib/python3.6/site-packages/nltk/tokenize/punkt.py", line 1382, in _match_potential_end_contexts
    before_words[match] = split[-1]
IndexError: list index out of range
```

I have modified it to preserve the lines (https://www.nltk.org/_modules/nltk/tokenize.html#word_tokenize) in both the reference and the hypothesis text. 
